### PR TITLE
add responsive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ export default defineComponent({
 | src    | String         |         | Youtube video link or ID. Required.                                                      |
 | width  | Number, String | 640     | Player width.                                                                            |
 | height | Number, String | 360     | Player height.                                                                           |
+| responsive | Boolean  | false     | Scales player to full width in a 16/9 aspect ratio. Ignores width and height setting.                                                                          |
 | host   | String         |         | Points host to correct origin for CORS.                                                  |
 | vars   | Object         |         | [Player parameters](https://developers.google.com/youtube/player_parameters#Parameters). |
 

--- a/src/YouTube.vue
+++ b/src/YouTube.vue
@@ -1,6 +1,6 @@
 <template>
   <div :style="wrapperStyle">
-    <div ref="youtube" :style="wrapperStyle"></div>
+    <div ref="youtube" :style="responsive ? iframeStyle : wrapperStyle"></div>
   </div>
 </template>
 
@@ -40,6 +40,10 @@ const YouTube = defineComponent({
       type: [Number, String] as PropType<number | string>,
       default: 640,
     },
+    responsive: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
     host: {
       type: String as PropType<string>,
       default: 'https://www.youtube.com',
@@ -51,6 +55,12 @@ const YouTube = defineComponent({
       return getYouTubeID(this.src) || this.src
     },
     wrapperStyle(): Record<string, string> {
+      if (this.responsive) {
+        return {
+          'padding-bottom': '56.25%',
+          position: 'relative',
+        }
+      }
       return {
         width: `${this.width}px`,
         height: `${this.height}px`,
@@ -122,8 +132,8 @@ const YouTube = defineComponent({
       this.initiated = true
       // eslint-disable-next-line no-undef
       this.player = new YT.Player(this.$refs.youtube as HTMLElement, {
-        height: this.height,
-        width: this.width,
+        height: this.responsive ? 0 : this.height,
+        width: this.responsive ? 0 : this.width,
         videoId: this.id,
         host: this.host,
         playerVars: this.vars,


### PR DESCRIPTION
I needed to embed the video responsively. There is now a prop 'responsive'; if it's set to true the player resizes automatically to the full width using a 16/9 aspect ratio.